### PR TITLE
Merge values for duplicate xml attributes

### DIFF
--- a/lib/SimpleSAML/Metadata/SAMLParser.php
+++ b/lib/SimpleSAML/Metadata/SAMLParser.php
@@ -1061,7 +1061,11 @@ class SAMLParser
                                 $values[] = $attrval->getString();
                             }
 
-                            $ret['EntityAttributes'][$name] = $values;
+                            if (empty($ret['EntityAttributes'][$name])) {
+                                $ret['EntityAttributes'][$name] = $values;
+                            } else {
+                                $ret['EntityAttributes'][$name] = array_merge($ret['EntityAttributes'][$name], $values);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fix SAMLParser library to store the values of multiple defined attributes in SAML Metadata.