### PR TITLE
Fix discopower search when key word is between parentheses

### DIFF
--- a/modules/discopower/www/assets/js/jquery.livesearch.js
+++ b/modules/discopower/www/assets/js/jquery.livesearch.js
@@ -4,7 +4,7 @@ jQuery.fn.liveUpdate = function (list) {
     if (list.length) {
         var rows = list.children('a'),
         cache = rows.map(function () {
-            return jQuery(this).text().toLowerCase();
+            return jQuery(this).text().toLowerCase().replace('\(', '');
         });
 
         this.keyup(filter).keyup().parents('form').submit(function () {
@@ -17,6 +17,7 @@ jQuery.fn.liveUpdate = function (list) {
     function filter()
     {
         var term = jQuery.trim(jQuery(this).val().toLowerCase()), scores = [];
+        term = term.replace('\(', '');
 
         if (!term) {
             rows.show();


### PR DESCRIPTION
If the name of the IdP includes a word between parentheses (e.g. "Foo Bar University (FBU)") and a user search for "FBU", the result will be an empty array. By removing the '(' from the available IdPs before filtering them the result will include all the matching IdPs