### PR TITLE
Preserve values of duplicate variables when parsing SAML metadata

### DIFF
--- a/lib/SimpleSAML/Metadata/SAMLParser.php
+++ b/lib/SimpleSAML/Metadata/SAMLParser.php
@@ -1107,7 +1107,11 @@ class SAMLParser
                                 $values[] = $attrval->getString();
                             }
 
-                            $ret['EntityAttributes'][$name] = $values;
+                            if (empty($ret['EntityAttributes'][$name])) {
+                                $ret['EntityAttributes'][$name] = $values;
+                            } else {
+                                $ret['EntityAttributes'][$name] = array_merge($ret['EntityAttributes'][$name], $values);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fix SAMLParser library to store the values of multiple defined attributes in SAML Metadata.